### PR TITLE
Fix plugin name in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ production (current)
 #####Install from CLI
   ```
   $ cf add-plugin-repo CF-Community http://plugins.cloudfoundry.org/
-  $ cf install-plugin targets -r CF-Community
+  $ cf install-plugin Targets -r CF-Community
   ```
   
   


### PR DESCRIPTION
The repository lists the name as "Targets", which makes the existing installation instructions fail with:

    Plugin targets not found in repository CF-Community.

Using `Targets` works fine.